### PR TITLE
Use type 'error' for errors

### DIFF
--- a/src/radix/error.clj
+++ b/src/radix/error.clj
@@ -24,13 +24,11 @@
   ([^Exception e]
      (error-response (error-message e) 500))
   ([message status]
-     (error-response message status "error"))
-  ([message status type]
      {:status status
       :headers {"Content-Type" "application/json"}
       :body {:message message
              :status status
-             :type type}}))
+             :type "error"}}))
 
 (defn id-error-response
   "Create a json-format response with a specific id included in the body."
@@ -74,8 +72,8 @@
     (try+
      (handler req)
      (catch [:type ::conflict] {:keys [message]}
-       (error-response (or message "Conflict") 409 "conflict"))
+       (error-response (or message "Conflict") 409))
      (catch [:type ::badrequest] {:keys [message]}
-       (error-response (or message "Bad request") 400 "badrequest"))
+       (error-response (or message "Bad request") 400))
      (catch [:type ::notfound] {:keys [message]}
-       (error-response (or message "Resource not found") 404 "notfound")))))
+       (error-response (or message "Resource not found") 404)))))

--- a/test/radix/error_test.clj
+++ b/test/radix/error_test.clj
@@ -13,9 +13,9 @@
                                         :body {:message "hello" :status 300 :type "error"}})
 
  (fact "error response builds json with message, status and type"
-       (error-response "hello" 123 "type") => {:status 123
-                                               :headers {"Content-Type" "application/json"}
-                                               :body {:message "hello" :status 123 :type "type"}})
+       (error-response "hello" 123) => {:status 123
+                                        :headers {"Content-Type" "application/json"}
+                                        :body {:message "hello" :status 123 :type "error"}})
 
  (fact "error response builds json with exception"
        (let [response (error-response (Exception. "hello"))
@@ -91,7 +91,7 @@
          (:status response) => 400
          (:body response) => {:status 400
                               :message ..message..
-                              :type "badrequest"}))
+                              :type "error"}))
 
  (fact "error of type conflict is trapped and response is generated"
        (let [handler (fn [req] (throw-conflict ..message..))
@@ -99,7 +99,7 @@
          (:status response) => 409
          (:body response) => {:status 409
                               :message ..message..
-                              :type "conflict"}))
+                              :type "error"}))
 
  (fact "error of type notfound with no message is trapped and response is generated"
        (let [handler (fn [req] (throw-not-found))
@@ -107,4 +107,4 @@
          (:status response) => 404
          (:body response) => {:status 404
                               :message "Resource not found"
-                              :type "notfound"})))
+                              :type "error"})))


### PR DESCRIPTION
Avoid breaking compatibility with existing APIs, and avoid encouraging
clients to dispatch on type rather than response status. No need to
declare a new type for each error status, these are fundamentally the
same error type.

Technically a breaking change, but a reasonably minor one in a recently
added feature.
