### PR TITLE
Added optional function to wrap-error-handling that allows logging...

### DIFF
--- a/docs/uberdoc.html
+++ b/docs/uberdoc.html
@@ -2865,7 +2865,7 @@ net.brehaut.ClojureTools = (function (SH) {
     build_tree: build_tree
   };
 })(SyntaxHighlighter);
-</script><title>mixradio/radix -- Marginalia</title></head><body><table><tr><td class="docs"><div class="header"><h1 class="project-name"><a href="https://github.com/mixradio/radix">mixradio/radix</a></h1><h2 class="project-version">1.0.11</h2><br /><p>A Clojure library providing the root functionality for web services</p>
+</script><title>mixradio/radix -- Marginalia</title></head><body><table><tr><td class="docs"><div class="header"><h1 class="project-name"><a href="https://github.com/mixradio/radix">mixradio/radix</a></h1><h2 class="project-version">1.0.12-SNAPSHOT</h2><br /><p>A Clojure library providing the root functionality for web services</p>
 </div><div class="dependencies"><h3>dependencies</h3><table><tr><td class="dep-name">environ</td><td class="dotted"><hr /></td><td class="dep-version">1.0.0</td></tr><tr><td class="dep-name">io.clj/logging</td><td class="dotted"><hr /></td><td class="dep-version">0.8.1</td></tr><tr><td class="dep-name">metrics-clojure</td><td class="dotted"><hr /></td><td class="dep-version">2.5.1</td></tr><tr><td class="dep-name">metrics-clojure-graphite</td><td class="dotted"><hr /></td><td class="dep-version">2.5.1</td></tr><tr><td class="dep-name">metrics-clojure-jvm</td><td class="dotted"><hr /></td><td class="dep-version">2.5.1</td></tr><tr><td class="dep-name">metrics-clojure-ring</td><td class="dotted"><hr /></td><td class="dep-version">2.5.1</td></tr><tr><td class="dep-name">ns-tracker</td><td class="dotted"><hr /></td><td class="dep-version">0.3.0</td></tr><tr><td class="dep-name">org.clojure/tools.logging</td><td class="dotted"><hr /></td><td class="dep-version">0.3.1</td></tr><tr><td class="dep-name">org.slf4j/slf4j-api</td><td class="dotted"><hr /></td><td class="dep-version">1.7.12</td></tr><tr><td class="dep-name">org.slf4j/jcl-over-slf4j</td><td class="dotted"><hr /></td><td class="dep-version">1.7.12</td></tr><tr><td class="dep-name">org.slf4j/jul-to-slf4j</td><td class="dotted"><hr /></td><td class="dep-version">1.7.12</td></tr><tr><td class="dep-name">org.slf4j/log4j-over-slf4j</td><td class="dotted"><hr /></td><td class="dep-version">1.7.12</td></tr><tr><td class="dep-name">slingshot</td><td class="dotted"><hr /></td><td class="dep-version">0.12.2</td></tr></table></div></td><td class="codes" style="text-align: center; vertical-align: middle;color: #666;padding-right:20px"><br /><br /><br />(this space intentionally left almost blank)</td></tr><tr><td class="docs"><div class="toc"><a name="toc"><h3>namespaces</h3></a><ul><li><a href="#radix.error">radix.error</a></li><li><a href="#radix.ignore-trailing-slash">radix.ignore-trailing-slash</a></li><li><a href="#radix.logging">radix.logging</a></li><li><a href="#radix.reload">radix.reload</a></li><li><a href="#radix.ring-metrics">radix.ring-metrics</a></li><li><a href="#radix.setup">radix.setup</a></li></ul></div></td><td class="codes">&nbsp;</td></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#radix.error" name="radix.error"><h1 class="project-name">radix.error</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(ns radix.error
   (:require [clojure.tools.logging :refer [error]]
@@ -2908,9 +2908,11 @@ net.brehaut.ClojureTools = (function (SH) {
   (throw+ {:type ::conflict :message message}))</pre></td></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(defn throw-not-found
   [&amp; [message]]
-  (throw+ {:type ::notfound :message message}))</pre></td></tr><tr><td class="docs"><p>A middleware function to catch and log uncaught exceptions, then return a nice json response to the client</p>
+  (throw+ {:type ::notfound :message message}))</pre></td></tr><tr><td class="docs"><p>A middleware function to catch and log uncaught exceptions, then return a nice json response to the client. If you
+  want to modify the logging context you can pass in an optional context-modifier function which accepts a map that
+  it can modify and then return.</p>
 </td><td class="codes"><pre class="brush: clojure">(defn wrap-error-handling
-  [handler]
+  [handler &amp; [context-modifier]]
   (wrap-log-details
    (fn [request]
      (let [start (System/currentTimeMillis)]
@@ -2918,8 +2920,9 @@ net.brehaut.ClojureTools = (function (SH) {
          (handler request)
          (catch Throwable e
            (let [request-time (- (System/currentTimeMillis) start)
-                 log-id (str (java.util.UUID/randomUUID))]
-             (with-logging-context (merge {:request-time request-time :log-id log-id} (ex-data e))
+                 log-id (str (java.util.UUID/randomUUID))
+                 context-modifier (or context-modifier identity)]
+             (with-logging-context (context-modifier (merge {:request-time request-time :log-id log-id} (ex-data e)))
                (error e)
                (id-error-response e log-id)))))))))</pre></td></tr><tr><td class="docs"><p>Middleware function to deal with client errors in a consistent and simple manner: put this
   function into the ring application's middleware chain and simply use the functions


### PR DESCRIPTION
…context to be modified e.g. to remove unwanted values, or to add new ones.

Why?  Slingshot errors have a :environment value and, in our case when beaver is used to send errors to logstash, there is an 'environment' value that we want to use (e.g. 'prod') which gets overwritten by the value of :environment in the error.  So, we want to save this value under a different key so that we can keep both.
