### PR TITLE
Added namespace to load and cache a json/edn config file in memory

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
                  [org.slf4j/jcl-over-slf4j "1.7.12"]
                  [org.slf4j/jul-to-slf4j "1.7.12"]
                  [org.slf4j/log4j-over-slf4j "1.7.12"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [sonian/carica "1.1.0"]]
 
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.1.3"]
                                   [midje "1.6.3"]]

--- a/src/radix/config.clj
+++ b/src/radix/config.clj
@@ -1,0 +1,42 @@
+(ns radix.config
+  "Helpers for accessing the application's config file, located on the classpath or filesystem"
+  (:require [carica.core :as carica]
+            [clojure.tools.logging :as log]
+            [environ.core :refer [env]])
+  (:import java.net.URL))
+
+(defn config-filepath
+  []
+  (or (env :app-config-path)
+      (format "%s-config.edn" (env :service-name "app"))))
+
+(defn file-exists?
+  [url-filepath]
+  (boolean
+   (try
+     (.openStream url-filepath)
+     (catch Exception _))))
+
+(defn load-resources-config
+  "Loads a config file located on the classpath, with reloading enabled."
+  [local-config]
+  (carica/configurer local-config []))
+
+(defn load-cached-config
+  "Loads and caches config at the filepath specified."
+  [filepath]
+  (let [url-filepath (URL. (str "file://" filepath))]
+    (if (file-exists? url-filepath)
+      (carica/configurer url-filepath [carica/cache-config])
+      (do (log/info "No config found at location:" filepath)
+          (constantly {})))))
+
+(defn make-config-fn
+  "Attempts to find and load a config file on the filesystem or the classpath."
+  [filepath]
+  (if-let [local-config (carica/resources filepath)]
+    (load-resources-config local-config)
+    (load-cached-config filepath)))
+
+(def config
+  (make-config-fn (config-filepath)))

--- a/test/radix/config_test.clj
+++ b/test/radix/config_test.clj
@@ -1,0 +1,33 @@
+(ns radix.config-test
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [environ.core :refer [env]]
+            [midje.sweet :refer :all]
+            [radix.config :refer :all]))
+
+(def ^:private test-config-map
+  {:foo 1, :bar "baz" :quux? true})
+
+(fact-group
+  "config-tests"
+  (fact "app config path env var takes precedence over resource path config"
+        (config-filepath) => ..appconfig..
+        (provided
+         (env :app-config-path) => ..appconfig..
+         (format anything anything) => nil :times 0))
+
+  (against-background [(before :contents (do (spit "/tmp/test-config.json" (json/generate-string test-config-map))
+                                             (spit "/tmp/test-config.edn" (pr-str test-config-map))))
+                       (after :contents (do (io/delete-file "/tmp/test-config.json")
+                                            (io/delete-file "/tmp/test-config.edn")))]
+    (fact "json and edn app config files are parsed correctly"
+          (let [json-config (make-config "/tmp/test-config.json")
+                edn-config (make-config "/tmp/test-config.edn")]
+            (json-config) => test-config-map
+            (edn-config) => test-config-map)))
+    
+  (fact "empty map is returned if the config isn't found"
+        (let [nil-config (make-config nil)
+              not-found-config (make-config (str (java.util.UUID/randomUUID)))]
+          (nil-config) => {}
+          (not-found-config) => {})))


### PR DESCRIPTION
Addition of the config namespace. 

It first tries to find the config by checking the file at `APP_CONFIG_PATH` and loads it into memory. If no file is found it will look for an `edn` config file on the classpath. If no files are found, the function returned by `make-config` returns an empty map.

Reloading of the config file at runtime is only enabled for the `edn` file on the classpath.