### PR TITLE
Add same config overrides in both local and remote configs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license "https://github.com/mixradio/radix/blob/master/LICENSE"
   :url "https://github.com/mixradio/radix"
 
-  :dependencies [[environ "1.0.0"]
+  :dependencies [[environ "1.0.1"]
                  [io.clj/logging "0.8.1"]
                  [metrics-clojure "2.3.0"]
                  [metrics-clojure-graphite "2.3.0"]
@@ -16,10 +16,12 @@
                  [org.slf4j/jul-to-slf4j "1.7.12"]
                  [org.slf4j/log4j-over-slf4j "1.7.12"]
                  [slingshot "0.12.2"]
-                 [sonian/carica "1.1.0"]]
+                 [sonian/carica "1.2.1"]]
 
-  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.1.3"]
-                                  [midje "1.6.3"]]
+  :profiles {:dev {:resource-paths ["test/resources"]
+                   :dependencies [[ch.qos.logback/logback-classic "1.1.3"]
+                                  [midje "1.7.0"]]
                    :plugins [[lein-midje "3.1.3"]
-                             [lein-marginalia "0.8.0"]]}
-             :provided {:dependencies [[org.clojure/clojure "1.6.0"]]}})
+                             [lein-marginalia "0.8.0"]]
+              
+                   :provided {:dependencies [[org.clojure/clojure "1.6.0"]]}}})

--- a/src/radix/config.clj
+++ b/src/radix/config.clj
@@ -1,14 +1,17 @@
 (ns radix.config
   "Helpers for accessing the application's config file, located on the classpath or filesystem"
-  (:require [carica.core :as carica]
+  (:require [carica
+             [core :as carica]
+             [map :refer [merge-nested]]
+             [middleware :as middleware]]
             [clojure.tools.logging :as log]
-            [environ.core :refer [env]])
+            [environ.core :as environ])
   (:import java.net.URL))
 
 (defn config-filepath
   []
-  (or (env :app-config-path)
-      (format "%s-config.edn" (env :service-name "app"))))
+  (or (environ/env :app-config-path)
+      (format "application-config.edn")))
 
 (defn file-exists?
   [url-filepath]
@@ -17,10 +20,27 @@
      (.openStream url-filepath)
      (catch Exception _))))
 
+(def override-config-fn
+  (middleware/env-override-config "ENVIRONMENT" :environments))
+
+(defn prevent-kw-vals
+  [m]
+  (doseq [[_ v] m]
+    (if (map? v)
+      (prevent-kw-vals v)
+      (when (keyword? v)
+        (throw (Exception. "keyword vals are not allowed in config map"))))))
+
+(defn validate-config-middleware
+  [f]
+  (fn [resources]
+    (doto (f resources)
+      prevent-kw-vals)))
+
 (defn load-resources-config
   "Loads a config file located on the classpath, with reloading enabled."
   [local-config]
-  (carica/configurer local-config []))
+  (carica/configurer local-config [override-config-fn validate-config-middleware]))
 
 (defn load-cached-config
   "Loads and caches config at the filepath specified."
@@ -29,7 +49,7 @@
     (if (file-exists? url-filepath)
       (carica/configurer url-filepath [carica/cache-config])
       (do (log/info "No config found at location:" filepath)
-          (constantly {})))))
+          (constantly nil)))))
 
 (defn make-config-fn
   "Attempts to find and load a config file on the filesystem or the classpath."
@@ -40,3 +60,32 @@
 
 (def config
   (make-config-fn (config-filepath)))
+
+(defmacro with-env-override
+  "Overrides the config function with the supplied environment variable in the lexical scope.
+
+  e.g with this config map:
+  
+  {:foo 1
+   :environments {:integration {:foo 2}}}
+
+  (with-env-override :integration
+    (config :foo))
+
+  (config :foo) evaluates to 2 in all threads"
+  [environment & body]
+  `(with-redefs [config (fn [& args#]
+                          (let [config-snapshot# (make-config-fn (config-filepath))]
+                            (-> (config-snapshot#)
+                                (~'carica.map/merge-nested (config-snapshot# :environments ~environment))
+                                (get-in args#))))]
+     ~@body))
+
+(defn env
+  "Attempts to find kw in the Carica config map. Falls back to environ's `env` fn if none is found."
+  ([kw]
+   (env kw nil))
+  ([kw default]
+   (or (or (config kw)
+           (environ/env kw))
+       default)))

--- a/src/radix/setup.clj
+++ b/src/radix/setup.clj
@@ -1,7 +1,7 @@
 (ns radix.setup
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [environ.core :refer [env]]
+            [radix.config :refer [env]]
             [metrics.jvm.core :refer [instrument-jvm]]
             [metrics.reporters.graphite :as graphite])
   (:import [java.io Reader]

--- a/test/radix/config_test.clj
+++ b/test/radix/config_test.clj
@@ -1,33 +1,56 @@
 (ns radix.config-test
-  (:require [cheshire.core :as json]
+  (:require [carica.core :as carica]
+            [cheshire.core :as json]
             [clojure.java.io :as io]
-            [environ.core :refer [env]]
+            [environ.core :as environ]
             [midje.sweet :refer :all]
-            [radix.config :refer :all]))
-
-(def ^:private test-config-map
-  {:foo 1, :bar "baz" :quux? true})
+            [radix.config :refer :all])
+  (:import java.net.URL))
 
 (fact-group
   "config-tests"
   (fact "app config path env var takes precedence over resource path config"
-        (config-filepath) => ..appconfig..
+        (config-filepath) => "app"
         (provided
-         (env :app-config-path) => ..appconfig..
+         (environ/env :app-config-path) => "app"
          (format anything anything) => nil :times 0))
 
-  (against-background [(before :contents (do (spit "/tmp/test-config.json" (json/generate-string test-config-map))
-                                             (spit "/tmp/test-config.edn" (pr-str test-config-map))))
+  (against-background [(before :contents (do (spit "/tmp/test-config.json" (json/generate-string (config)))
+                                             (spit "/tmp/test-config.edn" (pr-str (config)))))
                        (after :contents (do (io/delete-file "/tmp/test-config.json")
                                             (io/delete-file "/tmp/test-config.edn")))]
     (fact "json and edn app config files are parsed correctly"
-          (let [json-config (make-config "/tmp/test-config.json")
-                edn-config (make-config "/tmp/test-config.edn")]
-            (json-config) => test-config-map
-            (edn-config) => test-config-map)))
+          (let [json-config (make-config-fn "/tmp/test-config.json")
+                edn-config (make-config-fn "/tmp/test-config.edn")]
+            (json-config) => (config)
+            (edn-config) => (config))))
     
-  (fact "empty map is returned if the config isn't found"
-        (let [nil-config (make-config nil)
-              not-found-config (make-config (str (java.util.UUID/randomUUID)))]
-          (nil-config) => {}
-          (not-found-config) => {})))
+  (fact "nil is returned if the config isn't found"
+        (let [nil-config (make-config-fn nil)
+              not-found-config (make-config-fn (str (java.util.UUID/randomUUID)))]
+          (nil-config) => nil
+          (not-found-config) => nil))
+
+  (fact "env wrapper fn prefers config map values over environ vars"
+        (env :foo) => ..configvalue..
+        (provided
+         (config :foo) => ..configvalue..
+         (environ/env :foo) => ..envvalue.. :times 0))
+  
+  (fact "env wrapper fn falls back to environ env vars"
+        (env :foo) => ..envvalue..
+        (provided
+         (config :foo) => nil
+         (environ/env :foo) => ..envvalue..))
+  
+  (fact "env wrapper fn defaults to provided value if none are found"
+        (env :foo "default") => "default"
+        (provided
+         (config :foo) => nil
+         (environ/env :foo) => nil))
+
+  (fact "with-env-override overrides configs inside lexical scope"
+        (config :foo) => 1
+        (with-env-override :integration
+          (config :foo) => 2)
+        (config :foo) => 1))

--- a/test/resources/application-config.edn
+++ b/test/resources/application-config.edn
@@ -1,0 +1,4 @@
+{:foo 1
+ :bar "baz"
+ :quux? true
+ :environments {:integration {:foo 2}}}


### PR DESCRIPTION
#### new environ `env` wrapper function

The behaviour of `radix.config/env` is identical to `environ.core/env`, except that it first checks for the existence of a value in the carica config map before falling back to the environ map.

The purpose of this wrapper fn is to make it easy to port existing projects from environ to carica: by 1) directly copying the environ properties map from project.clj into `application-config.edn` and 2) replacing namespace require `[environ.core :refer [env]]` with `[radix.config :refer [env]]`in the entire project.

The `application-config.edn` file supports primitive types (not keywords: see below) so you can remove string quotes where applicable. Calling `valueOf` on an already parsed config value will have no effect, but functions like `parseInt` and `parseLong` will not compile: swapping them over to `valueOf` fixes this.

Once the tyranitar `application-properties.json` file is ported you can get rid of all the parsing code and access the config values using the `radix.config/config` function, which supports nesting of config values.
#### changed local resources config filename to `application-config.edn`

I've changed this from `${SERVICE_NAME}-config.edn` to `application-config.edn` to remove the dependency on the `SERVICE_NAME` environment variable.
#### environment config overrides

Allows for overriding config files by specifying the `ENVIRONMENTS` environment variable. For example:

```
{:retries 3
 :environments {:integration {:retries 1}}
```

`(config :retries)` evaluates to `1` when the `ENVIRONMENTS` env var is set to `integration`.

You can also use the `with-env-override` macro to override with a specific environment in the code:

```
(with-env-override :integration
  (config :retries)) ;; => 1
(config :retries) ;; => 3
```
#### keyword value exceptions

poke and prod config files are stored as JSON, which means keyword values are only usable inside the an EDN map. To prevent inconsistencies I've added middleware that parses the local EDN config map and throws an exception if a keyword value is found.
