### PR TITLE
No stack trace swallow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.idea
+*.iml

--- a/src/radix/error.clj
+++ b/src/radix/error.clj
@@ -66,7 +66,7 @@
                  log-id (str (java.util.UUID/randomUUID))
                  context-modifier (or context-modifier identity)]
              (with-logging-context (context-modifier (merge {:request-time request-time :log-id log-id} (ex-data e)))
-               (error e)
+               (error e (.getMessage e))
                (id-error-response e log-id)))))))))
 
 (defn wrap-client-errors


### PR DESCRIPTION
Ensure that stack traces are pushed to the logging framework when caught by the ring error handling middleware.
